### PR TITLE
chore: add serhatozdursun/resume to dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ coverage.xml
 .venv
 .env.*
 
+# Cloned resume app (see scripts/resume_env_setup.sh)
+/resume/
+
 # C extensions
 *.so
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,28 @@ Future: `SLACK_WEBHOOK_URL` for bug notifications (not wired yet).
 | Production | `https://www.serhatozdursun.com` |
 | Local resume app | `http://localhost:3000/` |
 
+### Two-repo layout
+
+| Repository | Role | Path after setup |
+|------------|------|------------------|
+| `serhatozdursun-ui-tests` (this repo) | Selenium/pytest suite | workspace root |
+| [serhatozdursun/resume](https://github.com/serhatozdursun/resume) | Next.js site under test | `resume/` (cloned by setup) |
+
+`scripts/cloud_env_setup.sh` clones and builds `resume/`. It does **not** start the server (agents start it when running local E2E).
+
+```bash
+# One-time / update (also run by cloud_env_setup.sh)
+bash scripts/resume_env_setup.sh
+
+# Start local site on :3000 (background)
+bash scripts/resume_start.sh
+
+# Run UI tests against local build (matches ui_local_pytest.yml)
+poetry run pytest --base_url http://localhost:3000/
+```
+
+`yarn dev` needs `.env.local` (see resume `env.example`); CI and `resume_start.sh` use `yarn build` + `yarn start` and do not require EmailJS keys.
+
 ---
 
 ## Agent 1 — UI Test Healer

--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ Run all tests against production (default):
 poetry run pytest
 ```
 
-Test the local website build (e.g. resume app on port 3000):
+Test the local website build ([serhatozdursun/resume](https://github.com/serhatozdursun/resume) on port 3000):
 
 ```bash
+bash scripts/resume_env_setup.sh   # clone + yarn install + build → resume/
+bash scripts/resume_start.sh       # serve on http://localhost:3000/
 poetry run pytest --base_url http://localhost:3000/
-# or
-poetry run pytest --base-url http://localhost:3000/
 ```
+
+`cloud_env_setup.sh` runs `resume_env_setup.sh` automatically but does not start the server.
 
 Use Firefox instead of Chrome:
 

--- a/scripts/cloud_env_setup.sh
+++ b/scripts/cloud_env_setup.sh
@@ -26,6 +26,9 @@ fi
 
 mkdir -p reports/html reports/screenshots reports/healer reports/discoverer
 
+echo "[env] Setting up resume website (serhatozdursun/resume)..."
+bash scripts/resume_env_setup.sh
+
 echo "[env] Running lint checks..."
 poetry run ruff check .
 poetry run ruff format --check .

--- a/scripts/resume_env_setup.sh
+++ b/scripts/resume_env_setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Clone and build serhatozdursun/resume for local UI tests on http://localhost:3000/
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESUME_DIR="${RESUME_DIR:-$ROOT/resume}"
+RESUME_REPO="${RESUME_REPO:-https://github.com/serhatozdursun/resume.git}"
+
+cd "$ROOT"
+
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "[resume] ERROR: yarn not found (Node.js required)"
+  exit 1
+fi
+
+if [ ! -d "$RESUME_DIR/.git" ]; then
+  echo "[resume] Cloning $RESUME_REPO into $RESUME_DIR"
+  git clone "$RESUME_REPO" "$RESUME_DIR"
+else
+  echo "[resume] Updating existing clone at $RESUME_DIR"
+  git -C "$RESUME_DIR" fetch origin main
+  git -C "$RESUME_DIR" checkout main
+  git -C "$RESUME_DIR" pull --ff-only origin main || true
+fi
+
+echo "[resume] Installing dependencies..."
+(cd "$RESUME_DIR" && yarn install --frozen-lockfile)
+
+echo "[resume] Building production bundle..."
+(cd "$RESUME_DIR" && yarn build)
+
+echo "[resume] Ready. Start with: bash scripts/resume_start.sh"

--- a/scripts/resume_start.sh
+++ b/scripts/resume_start.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Start the resume site on PORT (default 3000). Matches ui_local_pytest.yml CI flow.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESUME_DIR="${RESUME_DIR:-$ROOT/resume}"
+PORT="${PORT:-3000}"
+
+if [ ! -d "$RESUME_DIR/.next" ]; then
+  echo "[resume] No build found — run: bash scripts/resume_env_setup.sh"
+  exit 1
+fi
+
+cd "$RESUME_DIR"
+export PORT
+
+if curl -sf "http://localhost:${PORT}/" >/dev/null 2>&1; then
+  echo "[resume] Already running on http://localhost:${PORT}/"
+  exit 0
+fi
+
+echo "[resume] Starting on http://localhost:${PORT}/ (background)"
+nohup yarn start > /tmp/resume-server.log 2>&1 &
+PID=$!
+
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${PORT}/" >/dev/null; then
+    echo "[resume] Ready (pid $PID)"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[resume] Failed to start — see /tmp/resume-server.log"
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the [serhatozdursun/resume](https://github.com/serhatozdursun/resume) Next.js site to the Cloud Agent development environment so local E2E matches `ui_local_pytest.yml`.

## Changes

- **`scripts/resume_env_setup.sh`** — clone/update `resume/`, `yarn install --frozen-lockfile`, `yarn build`
- **`scripts/resume_start.sh`** — serve built app on `http://localhost:3000/`
- **`scripts/cloud_env_setup.sh`** — calls `resume_env_setup.sh` during VM update
- **`AGENTS.md` / `README.md`** — two-repo layout and local test commands
- **`.gitignore`** — ignore cloned `resume/` directory

## Verified locally

- Resume built and started on port 3000
- `poetry run pytest --base_url http://localhost:3000/` → 10/11 passed (1 failure: `test_experience_companies` — test data drift vs current resume `main`, not an env issue)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-398c09dc-28dd-4e61-b125-880a3df0cb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-398c09dc-28dd-4e61-b125-880a3df0cb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

